### PR TITLE
Fixes problems while using `dcosdev` and `dcosdev up`

### DIFF
--- a/dcosdev/commands.py
+++ b/dcosdev/commands.py
@@ -132,7 +132,9 @@ def up():
     artifacts = helper.collect_artifacts()
     print(">>> INFO: uploading "+str(artifacts))
     helper.upload_minio(artifacts)
-    os.remove('dist/'+package_name()+'-repo.json')
+    # Commented this Dir below because getting the following error:
+    # TypeError: 'unicode' object is not callable os.remove
+    # os.remove('dist/'+package_name()+'-repo.json')
     print('\nafter 1st up: dcos package repo add '+package_name+'-repo --index=0 http://minio.marathon.l4lb.thisdcos.directory:9000/artifacts/'+package_name+'/'+package_name+'-repo.json')
     print('\ndcos package install '+package_name+' --yes')
     print('\ndcos package uninstall '+package_name)

--- a/dcosdev/commands.py
+++ b/dcosdev/commands.py
@@ -132,9 +132,7 @@ def up():
     artifacts = helper.collect_artifacts()
     print(">>> INFO: uploading "+str(artifacts))
     helper.upload_minio(artifacts)
-    # Commented this Dir below because getting the following error:
-    # TypeError: 'unicode' object is not callable os.remove
-    # os.remove('dist/'+package_name()+'-repo.json')
+    os.remove('dist/'+package_name+'-repo.json')
     print('\nafter 1st up: dcos package repo add '+package_name+'-repo --index=0 http://minio.marathon.l4lb.thisdcos.directory:9000/artifacts/'+package_name+'/'+package_name+'-repo.json')
     print('\ndcos package install '+package_name+' --yes')
     print('\ndcos package uninstall '+package_name)

--- a/dcosdev/helper.py
+++ b/dcosdev/helper.py
@@ -42,13 +42,7 @@ def _read_config_values(artifacts_url):
     if os.path.exists("config.yml"):
         with open("config.yml") as f:
             config_values = yaml.safe_load(f.read()).get("values", dict())
-    
-    # Only works with Python 3.*
-    # return {**config_values, **global_values}
-
-    # For Python 2.*
-    config_values.update(global_values)
-    return config_values
+    return {**config_values, **global_values}
 
 def _prerender_file(config_values, filename):
     with open(filename) as f:

--- a/dcosdev/helper.py
+++ b/dcosdev/helper.py
@@ -42,8 +42,13 @@ def _read_config_values(artifacts_url):
     if os.path.exists("config.yml"):
         with open("config.yml") as f:
             config_values = yaml.safe_load(f.read()).get("values", dict())
-    return {**config_values, **global_values}
+    
+    # Only works with Python 3.*
+    # return {**config_values, **global_values}
 
+    # For Python 2.*
+    config_values.update(global_values)
+    return config_values
 
 def _prerender_file(config_values, filename):
     with open(filename) as f:


### PR DESCRIPTION
The following issues are listed and some remedies are included. 

One of the statements in `helper.py` is an expression that is used by Python 3.*   
`config_values.update(global_values)` now replaces `return {**config_values, **global_values}`

One of the statements in `commands.py` throws a `TypeError`:
Preferred commenting the expression and manually remove the directory `dist/<package_name>`. Someone found the possible problem [here](https://stackoverflow.com/questions/15883063/python-typeerror-unicode-object-is-not-callable-conflict-with-ugettext).

